### PR TITLE
docs: Fix few typographical errors

### DIFF
--- a/pages/01-Usage.md
+++ b/pages/01-Usage.md
@@ -22,7 +22,7 @@ Table of contents
 
 <a name="servsetup"></a>
 ## Setting up the server
-hydrus is a generic server that can serve a REST based API, using the Hydra APIDocumentation to understand the kind of data and the operations supported by the API. Getting a server running in hydrus is pretty straight forward. All you need to do is create a script that plugs the API Documentation, the database and a few other variables and start a hydrus app. An example of this is given below, in the following subsections, we will adress each part of the script and teach you how to create your own API using your API Documentation.
+hydrus is a generic server that can serve a REST based API, using the Hydra APIDocumentation to understand the kind of data and the operations supported by the API. Getting a server running in hydrus is pretty straight forward. All you need to do is create a script that plugs the API Documentation, the database and a few other variables and start a hydrus app. An example of this is given below, in the following subsections, we will address each part of the script and teach you how to create your own API using your API Documentation.
 
 ```python
 """Demo script for setting up an API using hydrus."""

--- a/pages/Design.md
+++ b/pages/Design.md
@@ -72,7 +72,7 @@ Annotations: the complete data of every instance reached by the client is still 
 The design of both database and datastore takes into account some of the different layers of representations possible using RDF. This multi-layered data layout tries to give tools to fashion representations using metadata and data concepts as useful abstractions.  
 Typically, statements (triples) are stored in the Graph according to 4 different types of layers. These layers make up the Knowledge Base that the REST layer queries.
 
-NOTE: for the sake of this text, the following tuple of words are synonims:
+NOTE: for the sake of this text, the following tuple of words are synonyms:
 * statement is triple
 * predicate is property
 

--- a/pages/Example.md
+++ b/pages/Example.md
@@ -26,7 +26,7 @@ Here a basic example of an hyperlink to another resource very common in every We
 ```
 <link rel="stylesheet" href="http://www.example.com/styles.css" />
 ```
-Linked Data allows to annotate the "quality" or "type" or "kind" of the objet referenced by using the link. An example in JSON-LD would thus look as follows.
+Linked Data allows to annotate the "quality" or "type" or "kind" of the object referenced by using the link. An example in JSON-LD would thus look as follows.
 
 #### EXAMPLE 2: Referencing a stylesheet in JSON-LD
 ```
@@ -156,7 +156,7 @@ Hydra classes are dereferenceable resources (see [definition](http://dbpedia.org
 
 Since Hydra uses classes to describe the information expected or returned by an operation, it also defines a concept to 
 describe the properties known to be supported by a class. The following example illustrates this feature. Instead of 
-referencing properties directly, `supportedPropert`y references an intermediate data structure, namely instances of the 
+referencing properties directly, `supportedProperty` references an intermediate data structure, namely instances of the 
 `SupportedProperty` class. This makes it possible to define whether a specific property is required or whether it is read-only or write-only depending on the class it is associated with.
 
 #### EXAMPLE 6: Defining a class and documenting its supported properties


### PR DESCRIPTION
Fixes few typographical errors, namely:
* ~adress~  ->  address
* ~synonims~  ->  synonyms
* ~objet~  ->  object
* ~supportedPropert~  ->  supportedProperty