### PR TITLE
Edited the Usage page

### DIFF
--- a/pages/01-Usage.md
+++ b/pages/01-Usage.md
@@ -22,7 +22,7 @@ Table of contents
 
 <a name="servsetup"></a>
 ## Setting up the server
-hydrus is a generic server that can serve a REST based API, using the Hydra APIDocumentation to understand the kind of data and the operations supported by the API. Getting a server running in hydrus is pretty straight forward. All you need to do is create a script that plugs the API Documentation, the database and a few other variables and start a hydrus app. An example of this is given below, in the following subsections, we will address each part of the script and teach you how to create your own API using your API Documentation.
+hydrus is a generic server that can serve a REST-based API using Hydra APIDocumentation to understand the type of data and the operations supported by the API. Getting a server running in hydrus is straightforward. Simply, create a script that plugs the API Documentation, the database along with a few other variables and start a hydrus app. An example of this is given below. In the following subsections, we will address each part of the script and show how to create your own API using your API Documentation.
 
 ```python
 """Demo script for setting up an API using hydrus."""
@@ -78,17 +78,17 @@ with set_api_name(app, API_NAME):
                 app.run(host='127.0.0.1', debug=True, port=8080)
 ```
 
-We will now break down each of these steps and understand what they really do. Let's begin.
+We will now break down each of these steps and understand what they do. Let's begin.
 
 <a name="apidoc"></a>
 ## The APIDocumentation
 Much of hydrus is built around the Hydra API Documentation. The API Doc is defined in the Hydra spec [here](http://www.hydra-cg.com/spec/latest/core/).
-The API Doc is the entity that tells hydrus how the server must be set up, what are the endpoints that must be created, what data needs to be served, the operations supported by the data and so on.
-hydrus uses Python classes in `hydrus.hydraspec.doc_writer` to create/define API Docs. A description of these classes and their design can be found in the [Design](https://github.com/HTTP-APIs/hydrus/wiki/Design) section.
+The API Doc is the entity that tells hydrus the way to set the server up, the endpoints that must be created, the data needs to be served, the operations supported by the data and so on.
+hydrus uses Python classes in `hydrus.hydraspec.doc_writer` to create and define API Docs. A description of these classes and how they are designed can be found in the [Design](https://github.com/HTTP-APIs/hydrus/wiki/Design) section.
 
 <!-- ![doc_writer](https://image.ibb.co/eWURkQ/doc_writer.png) -->
 
-The `hydurs.hydraspec.doc_writer.HydraDoc` object is crucial for hydrus to be able to set up the API. There are a number of ways you can create this object from your API Documentation:
+The `hydurs.hydraspec.doc_writer.HydraDoc` object is crucial for hydrus to be able to set up the API. There are various ways you can create this object from your API Documentation:
 
 <a name="newdoc"></a>
 ### Create a new API Documentation and a new `HydraDoc` object
@@ -113,7 +113,7 @@ apidoc = HydraDoc(API_NAME,
                    BASE_URL)
 ```
 
-The API Documentation is created, but it is not yet complete, we still need to add classes, properties and operations to the Doc. We also need to generate the EntryPoint object which is crucial for the API and it's operations to be discovered by a Hydra Client.
+The API Documentation has been created, but it is not yet complete. Classes, properties, and operations must be added to the Doc. An EntryPoint object must also be generated because it is crucial for the API and for its operations to be discoverable by a Hydra Client.
 
 We will now define a class for this API Documentation, which is of the type `HydraClass`
 ```python
@@ -127,7 +127,7 @@ class_ = HydraClass(class_uri, class_title, class_description, endpoint=False)
 # Setting endpoint=True creates an endpoint for the class itself, this is usually for classes that have single instances
 # These classes should not ideally have a Collection, although hydrus allows creation of such Collections
 ```
-Classes need to have properties that allow them to store information related to the class, much like attributes in a Python class, these are stored as `supportedProperty` of the `HydraClass`. Properties are defined as `HydraClassProp` objects:
+Classes need to have properties that allow them to store information related to the class. Similar to attributes in a Python class, these are stored as `supportedProperty` of the `HydraClass`. Properties are defined as `HydraClassProp` objects:
 ```python
 
 from hydrus.hydraspec.doc_writer import HydraClassProp
@@ -145,7 +145,7 @@ prop2 = HydraClassProp(prop1_uri, prop2_title, required=False, read=False, write
 # Properties that are read=True are read only
 # Properties that are write=True are writable
 ```
-Apart from properties, classes also need to have operations that allow them to modify the data stored within their instances, these operation are defined as `HydraClassOp` and are stored in `supportedOperation` of the `HydraClass`.
+Besides these properties, classes also need to have operations that can modify the data stored within their instances. These operation are defined as `HydraClassOp` and are stored in `supportedOperation` of the `HydraClass`.
 
 ```python
 from hydrus.hydraspec.doc_writer import HydraClassOp
@@ -164,7 +164,7 @@ op1 = HydraClassOp(op_name,
                    op_status)
 ```
 
-Once the classes and properties have been defined, we need to add them to the class.
+Once the classes and properties have been defined, add them to the class.
 
 ```python
 # Add the operation and properties to the Class
@@ -173,7 +173,7 @@ class_.add_supported_prop(prop2)
 
 class_.add_supported_op(op1)
 ```
-Now that we have defined a class along with it's properties and operations, we must add this class to the APIDocumentation.
+After defining a class along with its properties and operations, add this class to the APIDocumentation.
 
 ```python
 # Add the class to the HydraDoc
@@ -184,27 +184,27 @@ apidoc.add_supported_class(class_, collection=True)
 #       The collection inherently supports GET and PUT operations
 ```
 
-Apart from these, an API Documentation also needs to have the [Resource](http://www.w3.org/ns/hydra/core#Resource) and [Collection](http://www.w3.org/ns/hydra/core#Collection) classes, so that Resources, Collections and their members can be identified by the server. This can be done automatically using the `add_baseResource` and `add_baseCollection` methods.
+Other than this, an API Documentation also needs to have the [Resource](http://www.w3.org/ns/hydra/core#Resource) and the [Collection](http://www.w3.org/ns/hydra/core#Collection) classes, so that the server can identify the class members. This can be done automatically using the `add_baseResource` and `add_baseCollection` methods.
 
 ```python
 # Other operations
 apidoc.add_baseResource()  # Creates the base Resource Class and adds it to the API Documentation
 apidoc.add_baseCollection()    # Creates the base Collection Class and adds it to the API Documentation
 ```
-Finally we need to create the EntryPoint object for the API Documentation. All Collections are automatically assigned endpoints in the EntryPoint object. Classes that had their `endpoint` variables set to `True` are also assigned endpoints in the EntryPoint object, this object is created automatically by the `HydraDoc` object, and can be created using the `gen_EntryPoint` method.
+Finally, create the EntryPoint object for the API Documentation. All Collections are automatically assigned endpoints in the EntryPoint object. Classes that had their `endpoint` variables set to `True` are also assigned endpoints in the EntryPoint object. This object is created automatically by the `HydraDoc` object and can be created using the `gen_EntryPoint` method.
 ```python
 apidoc.gen_EntryPoint()    # Generates the EntryPoint object for the Doc using the Classes and Collections
 ```
-The final API Documentation can be viewed by calling the `generate` method which returns a Python dictionary containing the entire API Documentation. The `generate` method can be called for every class defined in the `doc_writer` module to generate a Python dictionary for it.
+The final API Documentation can be viewed by calling the `generate` method which returns a Python dictionary containing the entire API Documentation. The `generate` method can be called for every class defined in the `doc_writer` module to generate its own Python dictionary.
 ```python
 doc = apidoc.generate()  # Returns the entire API Documentation as a Python dict
 ```
-The complete script for this API Documentation can be found in `hydrus/hydraspec/doc_writer_sample.py`, the generated ApiDocumentation can be found in `hydrus/hydraspec/doc_writer_sample_output.py`.
+The complete script for this API Documentation can be found in `hydrus/hydraspec/doc_writer_sample.py`, and the generated ApiDocumentation can be found in `hydrus/hydraspec/doc_writer_sample_output.py`.
 
 <a name="olddoc"></a>
 ### Use an existing API Documentation to create a new `HydraDoc` object
 
-In case you already have an API Doc defined in JSON or a Python dict, hydrus provides a way to turn this API Doc into `doc_writer` classes. This is done using `hydrus.hydraspec.doc_maker` as defined below:
+In case you already have an API Doc defined in JSON or in a Python dict, hydrus provides a way to turn this API Doc into `doc_writer` classes. This is done using `hydrus.hydraspec.doc_maker` as defined below:
 ```python
 # Sample to convert the API Doc into doc_writer classes
 
@@ -234,10 +234,10 @@ JSON variables can such as `true`, `false` and `null` can be used as strings. Py
 
 <a name="dbsetup"></a>
 ## Setting up the database
-Now that we have defined the API Documentation, the next thing hydrus needs to function is a database to store the actual resources of the API. hydrus has it's own database models that are generic and can be used for most APIs, more information about these can be found in the [Design](https://github.com/HTTP-APIs/hydrus/wiki/Design) section.
+Now that the API Documentation has been defined, the next thing hydrus needs to function is a database to store the resources of the API. hydrus has its own database models that are generic and can be used for most APIs. More information about these can be found in the [Design](https://github.com/HTTP-APIs/hydrus/wiki/Design) section.
 
 The databse models use SQLAlchemy as an ORM Layer mapping relations to Python Classs and Objects. A good reference for the ORM can be found [here](http://docs.sqlalchemy.org/en/rel_1_0/orm/tutorial.html).
-Here is how we can create a new connection and create the necessary models for hydrus to use.
+Here is how to create a new connection and the necessary models for hydrus to use:
 
 A new connection to a database can be created as follows:
 ```python
@@ -245,20 +245,20 @@ from sqlalchemy import create_engine
 
 engine = create_engine('sqlite:///path/to/database/file')
 ```
-This engine acts as a connection on which we can create sessions to interact with the database. You can use any other database, we have used SQLite for the purpose of this demo. A list of possible database and how to connect to them can be found [here](http://docs.sqlalchemy.org/en/rel_1_0/orm/tutorial.html).
+This engine acts as a connection on which we can create sessions to interact with the database. Any other database can be used, but we have used SQLite for the purpose of this demo. A list of possible database and how to connect to them can be found [here](http://docs.sqlalchemy.org/en/rel_1_0/orm/tutorial.html).
 
-Once we have connected to the database we need to create the necessary models from hydrus:
+Once we have connected to the database, we need to create the necessary models from hydrus:
 
 ```python
 from hydrus.data.db_models import Base
 
 Base.metadata.create_all(engine)
 ```
-This will successfully create all required models in the connected database. The information of the API however is still not available in these models, to make them available, we need to use the API Doc to add metadata about the classes and their properties in the database. This can be done using the API Documentation object.
+This will successfully create all required models in the connected database. The information of the API, however, is still not available in these models. To make them available, use the API Doc to add metadata about the classes and their properties in the database. This can be done using the API Documentation object.
 
 <a name="classprop"></a>
 ## Adding Classes and Properties
-To add the classes and properties to hydrus, we need the same database `engine` in which we earlier created the models for hydrus. To this, we will add metadata using the HydraDoc object. This can be done using the `doc_parse` module in hydrus.
+To add the classes and properties to hydrus, we need the same database `engine` which we earlier created the models for hydrus. Add metadata to this by using the HydraDoc object. This can be done using the `doc_parse` module in hydrus.
 
 ```python
 from hydrus.data import doc_parse
@@ -300,20 +300,20 @@ properties = doc_parse.get_all_properties(classes)
 doc_parse.insert_classes(classes, session=db_session)
 doc_parse.insert_properties(properties, session=db_session)
 ```
-**NOTE:** You can use the `ApiDocumentation` dictionary directly to get the classes and properties, but it is advised that the `HydraDoc` object be used to generate the ApiDocumentation, as there may be unwanted errors in the dictionary that maybe permanently added to the database.
+**NOTE:** You can use the `ApiDocumentation` dictionary directly to get the classes and properties, but it is advised to use the `HydraDoc` object to generate the ApiDocumentation. Otherwise, there may be unwanted errors in the dictionary that are permanently added to the database.
 
 <a name="urls"></a>
 ## Server URL and the API name
-hydrus needs to know the server URL defined as `HYDRUS_SERVER_URL` at which it is hosted and the API name defined as `API_NAME`, which also serves as the entrypoint for the API.
+hydrus needs to know the server URL defined as `HYDRUS_SERVER_URL` at which it is hosted and the API name defined as `API_NAME` which also serves as the entrypoint for the API.
 
 These are used to define IDs for objects/resources that hydrus serves. For example, a hydrus server hosted at `https://hydrus.com/api` must return objects with ID `@id: https://hydrus.com/api/dummyClass/1`.
 
-It is essential for hydrus to know this, as the Hydra spec requres IDs for objects to be dereferencable links.
-Since most servers use an interface to link with the actual application or backend process, these things cannot be found out by hydrus on it's own and must be provided during setup.
+It is essential for hydrus to know this because the Hydra spec requires IDs for objects to be dereferencable links.
+Since most servers use an interface to link with the application or backend process, these things must be provided during setup and cannot be found out by hydrus on its own.
 
 <a name="appf"></a>
 ## App factory
-The API name, must also be used for hydrus to actually create an app. The `app_factory` method creates an API with all routes directed at `/[API_NAME]`, for example if you create an app using the `API_NAME` as `"demoapi"`, all operations for the API will be at the route `/demoapi/..`. The API name serves as the entrypoint for the application. We can create an app using the `API_NAME` as follows:
+The API name must also be used for hydrus to create an app. The `app_factory` method creates an API with all routes directed at `/[API_NAME]`. For example, if an app is created using the `API_NAME` as `"demoapi"`, all operations for the API will be at the route `/demoapi/..`. The API name serves as the entrypoint for the application. Create an app using the `API_NAME` as follows:
 
 ```python
 from hydrus.app import app_factory
@@ -325,7 +325,7 @@ app = app_factory(API_NAME)
 ```
 <a name="pnp"></a>
 ## Plug and Play
-Once everything needed to create a Hydra based API is in place, we must connect them to each other. This is done using the methods defined in the `hydrus.utils` module. The use of these pluggable modules requires an app context which a variant of the Python `context`, much like the request context in most servers. As such the Python keyword `with` must be used to create a context in which the application must run. This is done as follows:
+Once everything needed to create a Hydra based API is in place, connect them to each other. This is done by using the methods defined in the `hydrus.utils` module. The use of these pluggable modules requires an app context which is a variant of the Python `context`, similar to the request context in most servers. Due to this, the Python keyword `with` must be used to create a context in which the application must run. This is done as follows:
 ```python
 from hydrus.utils import set_api_name, set_doc, set_session, set_hydrus_server_url
 
@@ -340,9 +340,9 @@ with set_api_name(app, API_NAME):
                 # Start the hydrus app
                 app.run(host='127.0.0.1', debug=True, port=8080)
 ```
-The hydrus app is a modified instance of the Flask app with the required operations and routes predefined. All options/operations on the app object will be the same as those done in the Flask app.
+The hydrus app is a modified instance of the Flask app with the required operations and routes predefined. All options and operations on the app object will be the same as those done in the Flask app.
 
 <a name="test"></a>
 ## Running tests
-Will be added once dynamic tests are in place
+Will be added once dynamic tests are in place.
 


### PR DESCRIPTION
I fixed a couple simple grammatical and spelling errors. Mostly, I tried to reduce the amount of usage of "we" because this can make the instructions clearer. I also removed some words that are not needed from a couple of sentences. The overall goal of my edit was to make explanations as concise and as simple as possible. I hope this was helpful! Please let me know if I made any errors in my edits, and I'll fix them. 

Please approve the PR by Friday night. Thanks!