### PR TITLE
Correct template for Heading

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,7 +35,7 @@
 </a>
 
         <div class="site-info">
-          <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
+          <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.title }}</a></h1>
           <p class="site-description">{{ site.description }}</p>
         </div>
 


### PR DESCRIPTION
The jekyll template currently uses a `site.name` variable that doesn't exist. Since @Guttz moved to using `site.title` instead with #38 in 37b27b5