### PR TITLE
Correct code formatting

### DIFF
--- a/pages/hydrus-demo.md
+++ b/pages/hydrus-demo.md
@@ -25,30 +25,30 @@ Apart from this, there are also various Python packages that Hydrus uses. Using 
 To run a demo for Hydrus using the sample API, just do the following:
 
 Clone Hydrus:
-`bash
+```bash
 git clone https://github.com/HTTP-APIs/hydrus
-`
+```
 Change directory and switch to the develop branch:
-`bash
+```bash
 cd hydrus
 
 git checkout -b develop origin/develop
-`
+```
 
 Install hydrus using:
-`bash
+```bash
 pip install .
-`
+```
 or
-`bash
+```bash
 python setup.py install
-`
+```
 
 and run the server using:
 
-`bash
+```bash
 hydrus serve
-`
+```
 
 The demo should be up and running on `http://localhost:8080/serverapi/`.
 


### PR DESCRIPTION
The code given here uses ` (single ticks) which don't qualify as designated GitHub style markdown for newline code pre-formatting